### PR TITLE
Special keywords are not excluded as duplicates

### DIFF
--- a/javascript/prompt_format.js
+++ b/javascript/prompt_format.js
@@ -53,10 +53,15 @@
 				if (!cleanArray.includes(cleanedTag)) {
 					cleanArray.push(cleanedTag)
 					finalArray.push(tag)
-				} else {
-					finalArray.push(tag.replace(cleanedTag, ''))
+					return
 				}
 
+				if (/^(AND|BREAK)$/.test(cleanedTag)) {
+					finalArray.push(tag)
+					return
+				}
+
+				finalArray.push(tag.replace(cleanedTag, ''))
 			})
 
 			input = finalArray.join(', ')


### PR DESCRIPTION
Special keywords like `AND` and `BREAK` might be written multiple times within the prompt, so I've made changes to ensure they are not excluded even if they appear duplicated.

-[AND keyword](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Features#composable-diffusion)
-[BREAK keyword](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Features#break-keyword)
